### PR TITLE
Add unary minus functionality for MCE

### DIFF
--- a/src/evaluators/source-1.js
+++ b/src/evaluators/source-1.js
@@ -24,7 +24,7 @@ expr    ::= expr ? expr : expr
          |  expr(expr, expr, ...)
 binop   ::= + | - | * | / | % | < | > | <= | >= 
          | === | !== |  && | ||
-unop    ::= !
+unop    ::= ! | -
 */
 
 /* CONSTANTS: NUMBERS, STRINGS, TRUE, FALSE */

--- a/src/evaluators/source-1.js
+++ b/src/evaluators/source-1.js
@@ -649,6 +649,17 @@ function eval_toplevel(stmt) {
 
 const the_empty_environment = null;
 
+// the minus operation is overloaded to
+// support both binary minus and unary minus
+
+function minus(x, y) {
+    if (is_number(x) && is_number(y)) {
+      return x - y;
+    } else {
+      return -x;
+    }
+}
+
 // the global environment has bindings for all
 // primitive functions, including the operators
 
@@ -656,7 +667,7 @@ const primitive_functions = list(
        list("display",       display         ),
        list("error",         error           ),
        list("+",             (x,y) => x + y  ),
-       list("-",             (x,y) => x - y  ),
+       list("-",             (x,y) => minus(x, y)  ),
        list("*",             (x,y) => x * y  ),
        list("/",             (x,y) => x / y  ),
        list("%",             (x,y) => x % y  ),
@@ -748,6 +759,8 @@ parse_and_eval("true;");
 parse_and_eval("! (1 === 1);");
 parse_and_eval("(! (1 === 1)) ? 1 : 2;");
 parse_and_eval("'hello' + ' ' + 'world';");
+parse_and_eval("6 * -1;");
+parse_and_eval("-12 - 8;");
 */
 
 parse_and_eval("function factorial(n) { return n === 1 ? 1 : n * factorial(n - 1);} factorial(4);");


### PR DESCRIPTION
Currently, the unary minus operation is not supported by the MCE with only binary minus being supported.

For example, `parse_and_eval("-1;");` gives the following error: <br />
`Expected number on right hand side of operation, got undefined.` <br />This is a result of the second number argument not being received by the minus primitive function.