### PR TITLE
Non-Det MCE: make final program result accessible

### DIFF
--- a/src/evaluators/source-4-3.js
+++ b/src/evaluators/source-4-3.js
@@ -808,6 +808,7 @@ function user_print(object) {
 }
 
 let try_again = null;
+let final_result = undefined; // stores the final result of the program, useful for testing.
 
 function parse_and_run(str) {
     const exprs = make_block(parse(str));
@@ -817,10 +818,18 @@ function parse_and_run(str) {
         (val, next_alternative) => {
             announce_output(output_prompt);
             display(user_print(val));
-            try_again = next_alternative;
+            final_result = val;
+            
+            // assign a function to try_again so that when called,
+            // the result value is returned
+            try_again = () => {
+                next_alternative();
+                return final_result;
+            };
         },
         // ambeval failure
         () => {
+            final_result = undefined;
             announce_output(
                 "// There are no more values of");
             display(user_print(str));

--- a/src/evaluators/source-4-3.js
+++ b/src/evaluators/source-4-3.js
@@ -834,6 +834,7 @@ function parse_and_run(str) {
                 "// There are no more values of");
             display(user_print(str));
         });
+    return final_result;
 }
 
 // parse_and_run('function a(){const b = 2; return b;} a();');

--- a/src/evaluators/source-4-3.js
+++ b/src/evaluators/source-4-3.js
@@ -816,8 +816,6 @@ function parse_and_run(str) {
         the_global_environment,
         // ambeval success
         (val, next_alternative) => {
-            announce_output(output_prompt);
-            display(user_print(val));
             final_result = val;
             
             // assign a function to try_again so that when called,


### PR DESCRIPTION
Currently, the evaluator simply prints the final result of the program. <br />
eg. ` "// Amb-Eval value:" 
3
`

With this PR, the final result is kept track of in a global variable (`final_result`) thereby allowing it to be accessible after running `parse_and_run`. The final result is also returned upon invoking `parse_and_run` and `try_again`. These simplify the writing of test programs.